### PR TITLE
bugfix(issue-16): close modal with enter key

### DIFF
--- a/fish_research/public/js/form.js
+++ b/fish_research/public/js/form.js
@@ -21,6 +21,17 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
+  // close modal when enter key is pressed
+  document.addEventListener('keydown', function (event) {
+    if (
+      event.key === 'Enter' &&
+      !responseModal.classList.contains('hidden')
+    ) {
+      event.preventDefault();
+      closeModal();
+    }
+  });
+
   function closeModal() {
     responseModal.classList.add('hidden');
     responseMessage.innerHTML = '';


### PR DESCRIPTION
fixes: #16 
- adds functionality to close the submission modal with the enter key to prevent a loop of attempted resubmissions.