### PR TITLE
feat(issue-36): regex pattern match for chum dna ids

### DIFF
--- a/fish_research/projects/union_outmigration/models/Union_Outmigration.js
+++ b/fish_research/projects/union_outmigration/models/Union_Outmigration.js
@@ -15,7 +15,10 @@ const UnionOutmigrationSchema = mongoose.Schema({
   'Chum Fry': { type: Number },
   'Chum Fry Mort': { type: Number },
   'Chum DNA Taken': { type: Number },
-  'Chum DNA IDs': { type: String },
+  'Chum DNA IDs': {
+    type: String,
+    pattern: /^([A-Z]{2}\d{2})-(\d{1,3}) to \1-(\d{1,3})$|^-$/,
+  },
   'Chum Marked': { type: Number },
   'Chum Marked Mort': { type: Number },
   'Chum Recap': { type: Number },

--- a/fish_research/projects/union_outmigration/views/form.ejs
+++ b/fish_research/projects/union_outmigration/views/form.ejs
@@ -27,6 +27,7 @@
             id="date"
             required
             class="feedback-input"
+            max=""
           />
         </fieldset>
         <fieldset class="feedback-input col-span-2">
@@ -212,9 +213,9 @@
             type="text"
             id="chumDnaIds"
             class="feedback-input"
-            placeholder="If there are none, type -"
+            placeholder="eg: AA26-123 to AA26-456"
             required
-            title="if none, type -"
+            title="eg: AA26-123 to AA26-456, or if none, type '-'"
           />
         </fieldset>
         <fieldset class="feedback-input">

--- a/fish_research/public/css/form.css
+++ b/fish_research/public/css/form.css
@@ -58,6 +58,14 @@ fieldset:focus-within {
   border-color: var(--border-color-active);
 }
 
+/* make legend and input text red if input is invalid */
+fieldset:has(input:invalid),
+fieldset:has(select:invalid),
+fieldset:has(textarea:invalid) {
+  color: var(--text-color-error);
+  border-color: var(--text-color-error);
+}
+
 legend {
   font-weight: bold;
   text-transform: uppercase;

--- a/fish_research/public/js/unionOutmigrationForm.js
+++ b/fish_research/public/js/unionOutmigrationForm.js
@@ -45,6 +45,45 @@ document.addEventListener('DOMContentLoaded', function () {
     responseModal.classList.remove('hidden');
   }
 
+  // set max date for "Date" field to today, adjusting for timezone to ensure it works correctly regardless of user's local time
+  const dateInput = document.getElementById('date');
+  const today = new Date();
+  const timezoneOffset = today.getTimezoneOffset() * 60000;
+  const localToday = new Date(today.getTime() - timezoneOffset);
+  dateInput.max = localToday.toISOString().split('T')[0];
+
+  // regex pattern for "Chum DNA IDs" field: must be in the format "AA26-123 to AA26-456" or "-" if no IDs were taken
+  const chumDnaIdsPattern =
+    /^([A-Z]{2}\d{2})-(\d{1,3}) to \1-(\d{1,3})$|^-$/;
+
+  // automatically convert the letters after the leading ## to uppercase, and show them in the form that way,
+  //  but keep the " to " lowercase
+  const chumDnaIdsInput = document.getElementById('chumDnaIds');
+  chumDnaIdsInput.addEventListener('input', function () {
+    const start = this.selectionStart;
+    const end = this.selectionEnd;
+
+    const updatedValue = this.value
+      .toUpperCase()
+      .replace(/\bTO\b/g, 'to');
+
+    if (updatedValue !== this.value) {
+      this.value = updatedValue;
+      this.setSelectionRange(start, end);
+    }
+  });
+
+  // ensure the "Chum DNA IDs" field matches the required pattern before allowing form submission
+  chumDnaIdsInput.addEventListener('input', function () {
+    if (!chumDnaIdsPattern.test(this.value)) {
+      this.setCustomValidity(
+        'Please enter a valid Chum DNA ID range (e.g., AA26-123 to AA26-456) or "-" if no IDs were taken.',
+      );
+    } else {
+      this.setCustomValidity('');
+    }
+  });
+
   unionOutmigrationForm.addEventListener('submit', function (event) {
     event.preventDefault();
 


### PR DESCRIPTION
fixes #36 

### Addressed
- forces user to match the pattern similar to `AA##-### to AA##-###` or `-` for the 'Chum DNA IDs' input in the Union Outmigration form
- adds max date of today for date input
- styles all form inputs with red outline if it is invalid