### PR TITLE
feat(issue-37): add trap status button

### DIFF
--- a/fish_research/projects/union_outmigration/views/form.ejs
+++ b/fish_research/projects/union_outmigration/views/form.ejs
@@ -4,6 +4,7 @@
     <%- include("./partials/head", { title: "HCSEG - Union River Summer Chum FIFO" }) %>
     <link rel="stylesheet" href="/css/form.css" />
     <script src="/js/unionOutmigrationForm.js" defer></script>
+    <script src="/js/unionTrapStatus.js" defer></script>
   </head>
   <body>
     <%- include("./partials/header", { user: user, pageTitle: "Union River Summer Chum - Outmigration Program" }) %>
@@ -14,6 +15,7 @@
           <a href="/projects/union_outmigration/common-queries" class="btn btn-nav">Common Queries</a>
         <% } %>
         <a href="/projects" class="btn btn-nav">Return to Projects</a>
+        <button type="button" id="trapStatusBtn" class="btn btn-nav btn-trap-status">Trap Status</button>
       </div>
 
       <h3>*All Form Fields are Required*</h3>
@@ -325,7 +327,7 @@
         <fieldset class="feedback-input">
           <legend>*Coho Smolt Marked Morts:</legend>
           <input
-            name="Coho Smolt Marked Marked"
+            name="Coho Smolt Marked Mort"
             type="number"
             id="cohoSmoltMarkedMort"
             class="feedback-input"
@@ -587,6 +589,72 @@
         <input type="submit" value="SUBMIT" class="btn btn-submit" />
       </form>
     </main>
+
+    <!-- Trap Status Modal -->
+    <div id="trapStatusModal" class="modal hidden">
+      <div class="modal-overlay" id="trapStatusModalOverlay"></div>
+      <div class="modal-content trap-status-modal-content">
+        <button
+          id="trapStatusModalCloseBtn"
+          class="modal-close-btn"
+          aria-label="Close modal"
+        >
+          ✕
+        </button>
+        <h2 class="trap-status-modal-title">Trap Status Entry</h2>
+        <p class="trap-status-modal-subtitle">
+          All other form fields will be set to their null values (<i>N</i>, <i>0</i>, <i>-</i>, or <i>no reading</i>) automatically.
+        </p>
+        <div class="trap-status-form">
+          <fieldset class="feedback-input">
+            <legend>*Date:</legend>
+            <input
+              type="date"
+              id="trapStatusDate"
+              class="feedback-input"
+              required
+            />
+          </fieldset>
+          <fieldset class="feedback-input">
+            <legend>*Time:</legend>
+            <input
+              type="time"
+              id="trapStatusTime"
+              class="feedback-input"
+              value="00:00"
+              required
+            />
+          </fieldset>
+          <fieldset class="feedback-input trap-status-comments-field">
+            <legend>*Comments:</legend>
+            <div class="trap-status-radio-group">
+              <label class="trap-status-radio-label">
+                <input
+                  type="radio"
+                  name="trapStatusComment"
+                  value="No trap check."
+                  id="commentNoCheck"
+                  required
+                />
+                <span>No trap check.</span>
+              </label>
+              <label class="trap-status-radio-label">
+                <input
+                  type="radio"
+                  name="trapStatusComment"
+                  value="Cone lowered."
+                  id="commentConeLowered"
+                />
+                <span>Cone lowered.</span>
+              </label>
+            </div>
+          </fieldset>
+          <button type="button" id="trapStatusApplyBtn" class="btn btn-submit trap-status-apply-btn">
+            Apply to Form
+          </button>
+        </div>
+      </div>
+    </div>
 
     <!-- Modal popup for form submission response -->
     <div id="responseModal" class="modal hidden">

--- a/fish_research/public/css/form.css
+++ b/fish_research/public/css/form.css
@@ -231,6 +231,61 @@ label {
   grid-row: span 2;
 }
 
+.btn-trap-status {
+  background: none;
+  background-color: var(--text-color-accent);
+}
+
+.btn-trap-status:hover {
+  background: none;
+  background-color: var(--background-color-success);
+}
+
+.trap-status-modal-content {
+  max-width: 420px;
+  width: 92%;
+  padding: 2rem;
+}
+
+.trap-status-modal-title {
+  margin: 0 0 0.25rem;
+}
+
+.trap-status-modal-subtitle {
+  margin: 0 0 1.25rem;
+  color: var(--text-color-muted);
+}
+
+.trap-status-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.trap-status-comments-field {
+  width: 100%;
+}
+
+.trap-status-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-radius: 4px;
+}
+
+.trap-status-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.trap-status-apply-btn {
+  margin-top: 0.5rem;
+  width: 100%;
+}
+
 /* Responsiveness */
 @media screen and (max-width: 1400px) {
   .header .form-title {

--- a/fish_research/public/js/unionTrapStatus.js
+++ b/fish_research/public/js/unionTrapStatus.js
@@ -1,0 +1,169 @@
+/**
+ * Handles the "Trap Status" button flow:
+ *  1. Opens a focused modal to collect Date, Time, and Comment.
+ *  2. On "Apply to Form", pre-fills every main form field with null
+ *     values, then populates Date, Time, and Comments with the user's
+ *     choices so they can review before submitting.
+ */
+
+(function () {
+  const TRAP_STATUS_DEFAULTS = {
+    'Trap Operating': 'N',
+    RPM: 0,
+    Debris: 'null',
+    Visibility: 'null',
+    Flow: 'null',
+    'Water Temp': 0,
+    'Hobo Temp': 0,
+    'Chum Fry': 0,
+    'Chum Fry Mort': 0,
+    'Chum DNA Taken': 0,
+    'Chum DNA IDs': '-',
+    'Chum Marked': 0,
+    'Chum Marked Mort': 0,
+    'Chum Recap': 0,
+    'Chum Recap Mort': 0,
+    'Coho Fry': 0,
+    'Coho Fry Mort': 0,
+    'Coho Parr': 0,
+    'Coho Parr Mort': 0,
+    'Coho Smolt': 0,
+    'Coho Smolt Mort': 0,
+    'Coho Smolt Marked': 0,
+    'Coho Smolt Marked Mort': 0,
+    'Coho Smolt Recap': 0,
+    'Coho Smolt Recap Mort': 0,
+    Steelhead: 0,
+    'Steelhead Mort': 0,
+    'Steelhead Marked': 0,
+    'Steelhead Marked Mort': 0,
+    'Steelhead Recap': 0,
+    'Steelhead Recap Mort': 0,
+    Cutthroat: 0,
+    'Cutthroat Mort': 0,
+    Chinook: 0,
+    'Chinook Mort': 0,
+    Sculpin: 0,
+    'Sculpin Mort': 0,
+    Lamprey: 0,
+    'Lamprey Mort': 0,
+  };
+
+  /** Set a field value by its [name] attribute, handling radios/selects. */
+  function setFieldByName(form, fieldName, value) {
+    const els = form.querySelectorAll(
+      `[name="${CSS.escape(fieldName)}"]`,
+    );
+    if (!els.length) return;
+
+    const first = els[0];
+
+    if (first.type === 'radio') {
+      els.forEach((el) => {
+        el.checked = el.value === String(value);
+      });
+    } else if (first.tagName === 'SELECT') {
+      first.value = String(value);
+    } else {
+      first.value =
+        value !== null && value !== undefined ? value : '';
+    }
+  }
+
+  /** Today's date as YYYY-MM-DD (local time). */
+  function todayISO() {
+    const d = new Date();
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+
+  const trapStatusBtn = document.getElementById('trapStatusBtn');
+  const trapStatusModal = document.getElementById('trapStatusModal');
+  const trapStatusModalOverlay = document.getElementById(
+    'trapStatusModalOverlay',
+  );
+  const trapStatusModalCloseBtn = document.getElementById(
+    'trapStatusModalCloseBtn',
+  );
+  const trapStatusApplyBtn = document.getElementById(
+    'trapStatusApplyBtn',
+  );
+  const trapStatusDateInput =
+    document.getElementById('trapStatusDate');
+  const trapStatusTimeInput =
+    document.getElementById('trapStatusTime');
+  const mainForm = document.getElementById('unionOutmigrationForm');
+
+  if (!trapStatusBtn || !trapStatusModal || !mainForm) return; // guard
+
+  function openModal() {
+    // Restrict date to today or earlier
+    trapStatusDateInput.max = todayISO();
+    // Default time to midnight if not already set
+    if (!trapStatusTimeInput.value) {
+      trapStatusTimeInput.value = '00:00';
+    }
+    trapStatusModal.classList.remove('hidden');
+    trapStatusDateInput.focus();
+  }
+
+  function closeModal() {
+    trapStatusModal.classList.add('hidden');
+  }
+
+  trapStatusBtn.addEventListener('click', openModal);
+  trapStatusModalCloseBtn.addEventListener('click', closeModal);
+  trapStatusModalOverlay.addEventListener('click', closeModal);
+
+  // Close on Escape key
+  document.addEventListener('keydown', (e) => {
+    if (
+      e.key === 'Escape' &&
+      !trapStatusModal.classList.contains('hidden')
+    ) {
+      closeModal();
+    }
+  });
+
+  trapStatusApplyBtn.addEventListener('click', () => {
+    // Validate modal fields
+    const date = trapStatusDateInput.value;
+    const time = trapStatusTimeInput.value;
+    const commentRadio = trapStatusModal.querySelector(
+      'input[name="trapStatusComment"]:checked',
+    );
+
+    if (!date) {
+      trapStatusDateInput.focus();
+      trapStatusDateInput.reportValidity();
+      return;
+    }
+    if (!time) {
+      trapStatusTimeInput.focus();
+      trapStatusTimeInput.reportValidity();
+      return;
+    }
+    if (!commentRadio) {
+      return;
+    }
+
+    const comment = commentRadio.value;
+
+    // 1. Fill every zero/null field
+    Object.entries(TRAP_STATUS_DEFAULTS).forEach(([field, val]) => {
+      setFieldByName(mainForm, field, val);
+    });
+
+    // 2. Fill Date, Time, Comments from modal
+    setFieldByName(mainForm, 'Date', date);
+    setFieldByName(mainForm, 'Time', time);
+    const commentsTextarea = mainForm.querySelector('#comments');
+    if (commentsTextarea) commentsTextarea.value = comment;
+
+    // 3. Close modal and scroll to top of form so user can review
+    closeModal();
+    mainForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+})();


### PR DESCRIPTION
fixes: #37 

### Overview
- adds `Trap Status` button at the top of the Union Outmigration Form page
- allows any user to make an entry into the database where all form fields **except** `Date`, `Time`, and `Comments` are automatically filled out with their _NULL_ values
  - then, the user can
    - choose any date up to today
    - choose any time of day (defaults to midnight, as this is the convention for _NULL_ when the trap is not fishing)
    - choose a comment of either `No trap check.` or `Cone lowered.`
- once the user fills out these 3 fields and clicks `Apply to Form`, the user's selections and all other _NULL_ values are applied and the user is able to review the form before submitting
- the `Trap Status` modal allows the user to exit via the `close` button, the `esc` key, or by clicking outside of the modal
- if any of the 3 fields in the modal are not filled out, the modal will not apply to the form and will remain open when the user clicks the `Apply to Form` button